### PR TITLE
Release 0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dask-distance" %}
-{% set version = "0.1.0" %}
-{% set sha256 = "e5b972346bcd558a69f57e7d95e4c07cf8f2556fdeb3f24af24d18a920f8205b" %}
+{% set version = "0.2.0" %}
+{% set sha256 = "4264a7aa3aafb9e762225cf3b0ce58459ff0cfeb06b2af97b0834073fb3fb96f" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```markdown
### v0.2.0

* In `cdist`, use `_asarray` only for custom metrics. #67
* Fix a typo in `mahalanobis`' docstring. #68
* Document `cdist`'s/`pdist`'s keyword arguments V, VI, and w. #69
* Test `cdist`'s result shapes match. #70
* Simplify `_cdist_apply`. #72
* Fix spacing in `_cdist_apply`. #74
* Drop repeat in `_broadcast_uv`. #73
* Find `pdist` with known shape. #71
* In `cdist`, convert arrays to float then broadcast. #76
* Fix handling of metric string in `pdist`. #77
* Drop rechunking of `cdist`'s result. #78
* Use `_irange` in `pdist`. #80
* Support a single point in `pdist`. #83
* Add `_atleast_2d`. #86
* Drop unneeded Dask version check from tests. #85
* Set `pdist`'s default argument for known metrics. #87
* Format input array in `pdist`. #88
* Add `squareform`. #89
* Optimize `squareform`'s square matrix construction. #91
```